### PR TITLE
Clean up inconsistent spacing in README code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,32 @@ original developer : jamal@i11u.me
 After including jQuery, include ghostHunter:
 
 ````html
-    <script src="js/jquery.ghostHunter.min.js"></script>
+<script src="js/jquery.ghostHunter.min.js"></script>
 ````
 
 In your theme you'll need an `<input>` for the search query, the input should be in a `<form>` and you can use the form's submit functionality to call the search. This will work whether you have a standard submit button or if you use submit() in javascript.
+
 ````html
-    <form>
-      <input id="search-field" />
-      <input type="submit" value="search">
-    </form>
+<form>
+    <input id="search-field" />
+    <input type="submit" value="search">
+</form>
 ````
+
 You'll also need an area for the search results to show up:
+
 ````html
-    <section id="results"></section>
+<section id="results"></section>
 ````
+
 Now we can turn on the plugin, and that's all there is to it:
+
 ````js
-    $("#search-field").ghostHunter({
-      results   : "#results"
-    });
+$("#search-field").ghostHunter({
+    results: "#results"
+});
 ````
+
 ## How it works
 
 GhostHunter will attach itself to your search input field and wait for it to be focused on unless onPageLoad is set to "true". Once focus has gone to the field, the engine quickly gets to work building an index of your ghost posts that can easily be searched. When your visitor submits the form, GhostHunter will use either a default template or one provided by you to fill in your results element.
@@ -69,110 +75,129 @@ GhostHunter can be customized to a certain extent using very simple templating.
 You can include static pages in your search. By default, this is set to FALSE.
 
 ````js
-	$("#search-field").ghostHunter({
-		results   		: "#results",
-		includepages 	: true
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    includepages: true
+});
 ````
 
 
 ### Having search results appear on key up
 
 You can have the search results appear "as you type". Simply pass the onKeyUp parameter as true
+
 ````js
-	$("#search-field").ghostHunter({
-		results   		: "#results",
-		onKeyUp 		: true
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    onKeyUp: true
+});
 ````
+
 ### Preparing the search results with an API call on page-load
 
 You can have the api called when the page loads if the field is automatically in focus. Pass the onPageLoad parameter as true.
 For big blogs, this option should be set to True when using onKeyUp. This will increase the loading time of your blog page but will prevent excessive loading times when starting to type a request.
+
 ````js
-	$("#search-field").ghostHunter({
-		results   		: "#results",
-		onPageLoad 		: true
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    onPageLoad: true
+});
 ````
+
 ### Adding callbacks
 
 You can have Ghost Hunter call your callback function at two points. The first is right before it renders the information onto the page using the "before" option:
+
 ````js
-	$("#search-field").ghostHunter({
-		results   		: "#results",
-		before 			: function(){
-			alert("results are about to be rendered");
-		}
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    before: function() {
+        alert("results are about to be rendered");
+    }
+});
 ````
+
 The other callback is "onComplete" and gets called when the results have been rendered. It also provides an array of all the results:
+
 ````js
-	$("#search-field").ghostHunter({
-		results   		: "#results",
-		onComplete		: function( results ){
-			console.log( results );
-			alert("results have been rendered");
-		}
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    onComplete: function(results) {
+        console.log(results);
+        alert("results have been rendered");
+    }
+});
 ````
 
 ### Clearing the results
 
 You can use ghostHunter to clear the results of your query. ghostHunter will return an object relating to your search field and you can use that object to clear results.
+
 ````js
-	var searchField = 	$("#search-field").ghostHunter({
-							results   		: "#results",
-							onKeyUp 		: true
-					    });
+var searchField = $("#search-field").ghostHunter({
+    results: "#results",
+    onKeyUp: true
+});
 ````
+
 Now that the object is available to your code you can call it any time to clear your results:
+
 ````js
-	searchField.clear();
+searchField.clear();
 ````
+
 ### Hiding the search info
 
 If you don't want to show the search info at all you can pass this option
+
 ````js
-	$("#search-field").ghostHunter({
-		results   			: "#results",
-		displaySearchInfo 	: false
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    displaySearchInfo: false
+});
 ````
+
 ### Hiding the search info when the result is zero
 
 If you don't want to show the search info when the results are zero you can pass this option
 ````js
-	$("#search-field").ghostHunter({
-		results   			: "#results",
-		zeroResultsInfo 	: false
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    zeroResultsInfo: false
+});
 ````
+
 ### Customizing the html template
 
 The **result template** has access to these variables: title, description, link, pubDate.
 
 If you'd like to create your own you can use double curly brackets and pass the "results_template" option:
+
 ````js
-	$("#search-field").ghostHunter({
-		results   		: "#results",
-		result_template : "<a href='{{link}}'><p><h2>{{title}}</h2><h4>{{pubDate}}</h4>{{description}}</p></a>"
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    result_template: "<a href='{{link}}'><p><h2>{{title}}</h2><h4>{{pubDate}}</h4>{{description}}</p></a>"
+});
 ````
+
 The **info template** has one variable: amount.
 
 If you would like to modify the wording at the top, or have it say nothing you'll need to pass in the "info_template":
+
 ````js
-	$("#search-field").ghostHunter({
-		results   		: "#results",
-		info_template	: "<p>Number of posts found: {{amount}}</p>"
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    info_template: "<p>Number of posts found: {{amount}}</p>"
+});
 ````
+
 And of course, both can be included together:
+
 ````js
-	$("#search-field").ghostHunter({
-		results   		: "#results",
-		info_template	: "<p>Number of posts found: {{amount}}</p>",
-		result_template : "<a href='{{link}}'><p><h2>{{title}}</h2><h4>{{pubDate}}</h4>{{description}}</p></a>"
-    });
+$("#search-field").ghostHunter({
+    results: "#results",
+    info_template: "<p>Number of posts found: {{amount}}</p>",
+    result_template: "<a href='{{link}}'><p><h2>{{title}}</h2><h4>{{pubDate}}</h4>{{description}}</p></a>"
+});
 ````


### PR DESCRIPTION
no issue
- code examples were using a mixture of spaces and tabs and had large inconsistencies in indentation making them quite hard to read
- remove all use of tabs
- remove unnecessary indentation
- add newlines around code blocks to improve readability of raw markdown