### PR TITLE
Add '=' to URL param 'filter'

### DIFF
--- a/dist/jquery.ghosthunter-use-require.js
+++ b/dist/jquery.ghosthunter-use-require.js
@@ -405,7 +405,7 @@
 					fields: "id"
 				};
 
-        var url = "/ghost/api/v2/content/posts/?key=" + ghosthunter_key + "&limit=all&fields=id" + "&filter" + "updated_at:>\'" + this.latestPost.replace(/\..*/, "").replace(/T/, " ") + "\'";
+        var url = "/ghost/api/v2/content/posts/?key=" + ghosthunter_key + "&limit=all&fields=id" + "&filter=" + "updated_at:>\'" + this.latestPost.replace(/\..*/, "").replace(/T/, " ") + "\'";
 
 				var me = this;
         $.get(url).done(function(data){

--- a/dist/jquery.ghosthunter.js
+++ b/dist/jquery.ghosthunter.js
@@ -3387,7 +3387,7 @@ lunr.QueryParser.parseBoost = function (parser) {
 					fields: "id"
 				};
 
-        var url = "/ghost/api/v2/content/posts/?key=" + ghosthunter_key + "&limit=all&fields=id" + "&filter" + "updated_at:>\'" + this.latestPost.replace(/\..*/, "").replace(/T/, " ") + "\'";
+        var url = "/ghost/api/v2/content/posts/?key=" + ghosthunter_key + "&limit=all&fields=id" + "&filter=" + "updated_at:>\'" + this.latestPost.replace(/\..*/, "").replace(/T/, " ") + "\'";
 
 				var me = this;
         $.get(url).done(function(data){

--- a/src/ghosthunter-nodependency.js
+++ b/src/ghosthunter-nodependency.js
@@ -252,7 +252,7 @@
 				};
 
 				var url = "/ghost/api/v2/content/posts/?key=" +
-				ghosthunter_key + "&limit=all&fields=id" + "&filter" +
+				ghosthunter_key + "&limit=all&fields=id" + "&filter=" +
 				"updated_at:>\'" + this.latestPost.replace(/\..*/, "").replace(/T/, " ")  "\'";
 
 				var me = this;

--- a/src/ghosthunter.js
+++ b/src/ghosthunter.js
@@ -250,7 +250,7 @@
 					fields: "id"
 				};
 
-        var url = "/ghost/api/v2/content/posts/?key=" + ghosthunter_key + "&limit=all&fields=id" + "&filter" + "updated_at:>\'" + this.latestPost.replace(/\..*/, "").replace(/T/, " ") + "\'";
+        var url = "/ghost/api/v2/content/posts/?key=" + ghosthunter_key + "&limit=all&fields=id" + "&filter=" + "updated_at:>\'" + this.latestPost.replace(/\..*/, "").replace(/T/, " ") + "\'";
 
 				var me = this;
         $.get(url).done(function(data){


### PR DESCRIPTION
The API call was missing "=" in in the "filter" parameter. 

After the fix, it no longer requests all the posts from the server but only those that have been updated from the last reindex time.