### PR TITLE
DEV: Change variable names to prevent errors

### DIFF
--- a/dist/jquery.ghosthunter-use-require.js
+++ b/dist/jquery.ghosthunter-use-require.js
@@ -183,7 +183,7 @@
 		resultsData			: false,
 		onPageLoad			: false,
 		onKeyUp				: false,
-		result_template 	: "<a id='gh-{{ref}}' class='gh-search-item' href='{{link}}'><p><h2>{{title}}</h2><h4>{{prettyPubDate}}</h4></p></a>",
+		result_template 	: "<a id='gh-{{ref}}' class='gh-search-item' href='{{postLink}}'><p><h2>{{title}}</h2><h4>{{pubDate}}</h4></p></a>",
 		info_template		: "<p>Number of posts found: {{amount}}</p>",
 		displaySearchInfo	: true,
 		zeroResultsInfo		: true,
@@ -304,7 +304,7 @@
 						title: arrayItem.title,
 						description: arrayItem.custom_excerpt,
 						pubDate: prettyDate(parsedData.pubDate),
-						link: localUrl,
+						postLink: localUrl,
 						tags: tag_arr
 					};
 					// If there is a metadata "pre"-processor for the item, run it here.

--- a/dist/jquery.ghosthunter.js
+++ b/dist/jquery.ghosthunter.js
@@ -3165,7 +3165,7 @@ lunr.QueryParser.parseBoost = function (parser) {
 		resultsData			: false,
 		onPageLoad			: false,
 		onKeyUp				: false,
-		result_template 	: "<a id='gh-{{ref}}' class='gh-search-item' href='{{link}}'><p><h2>{{title}}</h2><h4>{{prettyPubDate}}</h4></p></a>",
+		result_template 	: "<a id='gh-{{ref}}' class='gh-search-item' href='{{postLink}}'><p><h2>{{title}}</h2><h4>{{pubDate}}</h4></p></a>",
 		info_template		: "<p>Number of posts found: {{amount}}</p>",
 		displaySearchInfo	: true,
 		zeroResultsInfo		: true,
@@ -3287,7 +3287,7 @@ lunr.QueryParser.parseBoost = function (parser) {
 						title: arrayItem.title,
 						description: arrayItem.custom_excerpt,
 						pubDate: prettyDate(parsedData.pubDate),
-						link: localUrl,
+						postLink: localUrl,
 						tags: tag_arr
 					};
 					// If there is a metadata "pre"-processor for the item, run it here.


### PR DESCRIPTION
This PR changes the variable names of `link` and `prettyPubDate` to prevent errors in the current version of Ghost.

When adding a custom option for `result_template` and using `{{link}}` an error is given that you cannot use `{{#link}}` without an `href` attribute.

`{{prettyPubDate}}` has been changed to `pubDate` elsewhere, but was not changed in the default `result_template`.
